### PR TITLE
Add an option to create ODS files in buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,16 @@ ods.close_table
 ods.close_file
 ```
 
-### Aditional options
+### Create ODS in buffer
+
+It is possible to avoid writing the file to disk if you pass a StringIO object as the first parameter. You will still need to close the file before reading the buffer.
 
 ```ruby
-ods = MinimalistODS.new(
-  save_to_disk: false # Allows you to create only the buffer of the ODS file
-  # A filename is not required if set to false. You can retrieve the data using the 'file_buffer' method after closing the file.
-)
+file_buffer = StringIO.new
+ods = MinimalistODS.new(file_buffer)
+...
+ods.close_file
+# Do something with file_buffer.read
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ ods.close_table
 ods.close_file
 ```
 
+### Aditional options
+
+```ruby
+ods = MinimalistODS.new(
+  save_to_disk: false # Allows you to create only the buffer of the ODS file
+  # A filename is not required if set to false. You can retrieve the data using the 'file_buffer' method after closing the file.
+)
+```
+
 ## Contributions
 
 Contributions are welcome. Please open an issue or a pull request on the [GitHub repository](https://github.com/tachomex/minimalist_ods).

--- a/minimalist_ods.gemspec
+++ b/minimalist_ods.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "minimalist_ods"
-  spec.version       = "0.1.0"
+  spec.version       = "0.2.0"
   spec.authors       = ["Gilberto Vargas"]
   spec.email         = ["tachoguitar@gmail.com"]
   spec.summary       = %q{A minimalist ODS generator}


### PR DESCRIPTION
These changes allow the user to create the files without writing anything to the disk. Due to the way zip files work (and limitations with the rubyzip library) some refactoring needed to be done, but the end user shouldn't be noticing any difference on their end.